### PR TITLE
Fixed retrieving watermark size from options

### DIFF
--- a/sorl_watermarker/engines/base.py
+++ b/sorl_watermarker/engines/base.py
@@ -70,13 +70,13 @@ class WatermarkEngineBase(ThumbnailEngineBase):
             options['cropbox'] = None
         if not 'watermark_alpha' in options:
             options['watermark_alpha'] = settings.THUMBNAIL_WATERMARK_OPACITY
-
-        if 'watermark_size' in options or settings.THUMBNAIL_WATERMARK_SIZE:
-            mark_sizes = options.get('watermark_size', settings.THUMBNAIL_WATERMARK_SIZE)
+        
+        mark_sizes = options.get('watermark_size', settings.THUMBNAIL_WATERMARK_SIZE)
+        if mark_sizes:
             try:
                 options['watermark_size'] = parse_geometry(
-                                    mark_sizes,
-                                    self.get_image_ratio(image, options))
+                                            mark_sizes,
+                                            self.get_image_ratio(image, options))
             except TypeError, e:
                 raise TypeError('Please, update sorl-thumbnail package version to  >= 11.12b. %s' % e)
         else:


### PR DESCRIPTION
This change fix issue when same thumbnail options used for more than one create_image method. After first execution watermark_size options set equals False if not present, and in next execution we get "argument of type 'bool' is not iterable" exception.
