### PR TITLE
Update base so that it uses the STATIC_ROOT to find the file on production servers.

### DIFF
--- a/sorl_watermarker/engines/base.py
+++ b/sorl_watermarker/engines/base.py
@@ -70,7 +70,7 @@ class WatermarkEngineBase(ThumbnailEngineBase):
         # Note - I do not think find can be used for this purpose - it is used for collecting static files to the static folder
         # Use os.path.join with the static root instead, and if not found, raise the error.
         watermark_path = find(watermark_img)
-        if not watermark.path:
+        if not watermark_path:
             watermark_path = os.path.join(settings.STATIC_ROOT, watermark_img)
             if not os.path.isfile(watermark_path):
                 raise AttributeError('Trying to apply a watermark, '


### PR DESCRIPTION
Update base so that it uses the STATIC_ROOT to find the file on production servers.  The find command only searches the apps and STATICFILES_DIRS.  In the event you use the static folder directly, it does not find the file.  Also, added an error trap so that if it does not find the file, it raises an error immediately.
